### PR TITLE
Enable building for kugo

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -29,6 +29,7 @@ SOMC_PLATFORM := loire
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 
 CM_BUILD := suzu
+CM_BUILD := kugo
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += \


### PR DESCRIPTION
There doesn't seem to be anything specific to suzu in this repo, aside from this line. Rather than periodically rebasing on top of your work, it might be easier to use the same `device/sony/loire` and `device/sony/common`.

Thoughts?