### PR TITLE
audio platform info: set SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES acdb_id

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -29,6 +29,7 @@
     <acdb_ids>
         <!-- Custom mapping starts here -->
         <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="124"/>
+        <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" acdb_id="799"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="101"/>
         <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="4"/>


### PR DESCRIPTION
Volume through speaker is low. It's played via output-speaker+wired_headphone port. Set appropriate acdb_id to achieve volume identical to output-speaker port.